### PR TITLE
Remove ms net http public version

### DIFF
--- a/src/RAML.API.Core/Properties/AssemblyInfo.cs
+++ b/src/RAML.API.Core/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.8.4")]
-[assembly: AssemblyFileVersion("0.8.4")]
+[assembly: AssemblyVersion("0.10.1")]
+[assembly: AssemblyFileVersion("0.10.1")]

--- a/src/RAML.API.Core/Properties/AssemblyInfo.cs
+++ b/src/RAML.API.Core/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("RAML.Api.Core")]
-[assembly: AssemblyDescription("Forked by Cvent on version 0.9.10 - Core API support classes for the RAML tools package")]
+[assembly: AssemblyDescription("Core API support classes for the RAML tools package")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("MuleSoft Inc")]
 [assembly: AssemblyProduct("RAML.Api.Core")]

--- a/src/RAML.API.Core/Properties/AssemblyInfo.cs
+++ b/src/RAML.API.Core/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("RAML.Api.Core")]
-[assembly: AssemblyDescription("Core API support classes for the RAML tools package")]
+[assembly: AssemblyDescription("Forked by Cvent on version 0.9.10 - Core API support classes for the RAML tools package")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("MuleSoft Inc")]
 [assembly: AssemblyProduct("RAML.Api.Core")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.10")]
-[assembly: AssemblyFileVersion("0.9.10")]
+[assembly: AssemblyVersion("0.8.4")]
+[assembly: AssemblyFileVersion("0.8.4")]

--- a/src/RAML.API.Core/Raml.Api.Core.csproj
+++ b/src/RAML.API.Core/Raml.Api.Core.csproj
@@ -44,16 +44,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http.Extensions, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net45+win8+wpa81\System.Net.Http.Extensions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Net.Http.Formatting">
       <HintPath>..\lib\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net45+win8+wpa81\System.Net.Http.Primitives.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
@@ -279,9 +271,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/RAML.API.Core/Raml.Api.Core.nuspec
+++ b/src/RAML.API.Core/Raml.Api.Core.nuspec
@@ -10,7 +10,7 @@
 	<licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
 	<iconUrl>http://raml.org/images/logo.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>Forked by Cvent on version 0.9.10 - Core API support classes for the RAML tools package</description>
+    <description>Core API support classes for the RAML tools package</description>
     <copyright>Copyright © 2015 MuleSoft</copyright>
     <tags>RAML REST API SCHEMA MARKUP CLIENT SERVICE</tags>
       <dependencies>

--- a/src/RAML.API.Core/Raml.Api.Core.nuspec
+++ b/src/RAML.API.Core/Raml.Api.Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>RAML.Api.Core</id>
-    <version>0.9.10</version>
+    <version>0.8.4</version>
     <title>RAML.Api.Core</title>
     <authors>MuleSoft Inc</authors>
     <owners>MuleSoft Inc</owners>
@@ -10,11 +10,10 @@
 	<licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
 	<iconUrl>http://raml.org/images/logo.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>Core API support classes for the RAML tools package</description>
+    <description>Forked by Cvent on version 0.9.10 - Core API support classes for the RAML tools package</description>
     <copyright>Copyright © 2015 MuleSoft</copyright>
     <tags>RAML REST API SCHEMA MARKUP CLIENT SERVICE</tags>
       <dependencies>
-          <dependency id="Microsoft.Net.Http" version="2.2.29" />
           <dependency id="Newtonsoft.Json" version="6.0.4" />
       </dependencies>
   </metadata>

--- a/src/RAML.API.Core/Raml.Api.Core.nuspec
+++ b/src/RAML.API.Core/Raml.Api.Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>RAML.Api.Core</id>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <title>RAML.Api.Core</title>
     <authors>MuleSoft Inc</authors>
     <owners>MuleSoft Inc</owners>

--- a/src/RAML.API.Core/Raml.Api.Core.nuspec
+++ b/src/RAML.API.Core/Raml.Api.Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>RAML.Api.Core</id>
-    <version>0.8.4</version>
+    <version>0.10.0</version>
     <title>RAML.Api.Core</title>
     <authors>MuleSoft Inc</authors>
     <owners>MuleSoft Inc</owners>

--- a/src/RAML.API.Core/XmlSerializerFormatter.cs
+++ b/src/RAML.API.Core/XmlSerializerFormatter.cs
@@ -18,7 +18,7 @@ namespace RAML.Api.Core
             SupportedEncodings.Add(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         }
 
-        public override Task WriteToStreamAsync(Type type, object value, Stream writeStream, HttpContent content,
+        public Task WriteToStreamAsync(Type type, object value, Stream writeStream, HttpContent content,
             TransportContext transportContext)
         {
             var taskSource = new TaskCompletionSource<object>();

--- a/src/RAML.API.Core/packages.config
+++ b/src/RAML.API.Core/packages.config
@@ -1,7 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable45-net45+win8+wpa81" />
 </packages>

--- a/src/Raml.Api.Core.Tests/ComplexJsonSchemaTests.cs
+++ b/src/Raml.Api.Core.Tests/ComplexJsonSchemaTests.cs
@@ -2,13 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Formatting;
 using System.Text;
 using System.Threading.Tasks;
 using Fstab.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using System.Net.Http.Formatting;
 
 namespace Raml.Api.Core.Tests
 {

--- a/src/Raml.Api.Core.Tests/Raml.Api.Core.Tests.csproj
+++ b/src/Raml.Api.Core.Tests/Raml.Api.Core.Tests.csproj
@@ -45,9 +45,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\lib\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Raml.Api.Core.Tests/Raml.Api.Core.Tests.csproj
+++ b/src/Raml.Api.Core.Tests/Raml.Api.Core.Tests.csproj
@@ -45,16 +45,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
@@ -90,9 +82,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Raml.Api.Core.Tests/packages.config
+++ b/src/Raml.Api.Core.Tests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/Raml.Api.Core.Tests/packages.config
+++ b/src/Raml.Api.Core.Tests/packages.config
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Removing Microsoft.Net.Http package which in turn removes Microsoft.Bcl and Microsoft.Bcl.Builds which aren't necessary for this package.